### PR TITLE
Remove max_size parameter

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -48,7 +48,7 @@ Usage Example
     display = ST7789(display_bus, width=240, height=240, rowstart=80)
 
     # Make the display context
-    splash = displayio.Group(max_size=10)
+    splash = displayio.Group()
     display.show(splash)
 
     color_bitmap = displayio.Bitmap(240, 240, 1)

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -6,3 +6,62 @@ Ensure your device works with this simple test.
 .. literalinclude:: ../examples/st7789_simpletest.py
     :caption: examples/st7789_simpletest.py
     :linenos:
+
+240x135
+=======
+
+.. literalinclude:: ../examples/st7789_240x135_simpletest.py
+    :caption: examples/st7789_240x135_simpletest.py
+    :linenos:
+
+320x240
+=======
+
+.. literalinclude:: ../examples/st7789_320x240_simpletest.py
+    :caption: examples/st7789_320x240_simpletest.py
+    :linenos:
+
+Product specific examples
+-------------------------
+
+1.14" Mini PiTFT
+================
+
+.. literalinclude:: ../examples/st7789_240x135_pitft_simpletest.py
+    :caption: examples/st7789_240x135_pitft_simpletest.py
+    :linenos:
+
+1.3" TFT Bonnet
+===============
+
+.. literalinclude:: ../examples/st7789_240x240_bonnet_simpletest.py
+    :caption: examples/st7789_240x240_bonnet_simpletest.py
+    :linenos:
+
+1.3" PiTFT
+==========
+
+.. literalinclude:: ../examples/st7789_240x240_pitft_simpletest.py
+    :caption: examples/st7789_240x240_pitft_simpletest.py
+    :linenos:
+
+Gizmo
+=====
+
+.. literalinclude:: ../examples/st7789_tft_gizmo_simpletest.py
+    :caption: examples/st7789_tft_gizmo_simpletest.py
+    :linenos:
+
+Pimoroni Pico Display Pack
+==========================
+
+.. literalinclude:: ../examples/st7789_240x135_simpletest_Pimoroni_Pico_Display_Pack.py
+    :caption: examples/st7789_240x135_simpletest_Pimoroni_Pico_Display_Pack.py
+    :linenos:
+
+Pimoroni Pico Explorer
+======================
+
+.. literalinclude:: ../examples/st7789_240x240_simpletest_Pimoroni_Pico_Explorer.py
+    :caption: examples/st7789_240x240_simpletest_Pimoroni_Pico_Explorer.py
+    :linenos:

--- a/examples/st7789_240x135_pitft_simpletest.py
+++ b/examples/st7789_240x135_pitft_simpletest.py
@@ -33,7 +33,7 @@ display = ST7789(
 )
 
 # Make the display context
-splash = displayio.Group(max_size=10)
+splash = displayio.Group()
 display.show(splash)
 
 color_bitmap = displayio.Bitmap(display.width, display.height, 1)
@@ -59,7 +59,6 @@ text = "Hello World!"
 text_area = label.Label(terminalio.FONT, text=text, color=TEXT_COLOR)
 text_width = text_area.bounding_box[2] * FONTSCALE
 text_group = displayio.Group(
-    max_size=10,
     scale=FONTSCALE,
     x=display.width // 2 - text_width // 2,
     y=display.height // 2,

--- a/examples/st7789_240x135_simpletest.py
+++ b/examples/st7789_240x135_simpletest.py
@@ -31,7 +31,7 @@ display = ST7789(
 )
 
 # Make the display context
-splash = displayio.Group(max_size=10)
+splash = displayio.Group()
 display.show(splash)
 
 color_bitmap = displayio.Bitmap(display.width, display.height, 1)
@@ -57,7 +57,6 @@ text = "Hello World!"
 text_area = label.Label(terminalio.FONT, text=text, color=TEXT_COLOR)
 text_width = text_area.bounding_box[2] * FONTSCALE
 text_group = displayio.Group(
-    max_size=10,
     scale=FONTSCALE,
     x=display.width // 2 - text_width // 2,
     y=display.height // 2,

--- a/examples/st7789_240x135_simpletest_Pimoroni_Pico_Display_Pack.py
+++ b/examples/st7789_240x135_simpletest_Pimoroni_Pico_Display_Pack.py
@@ -30,7 +30,7 @@ display = ST7789(
 )
 
 # Make the display context
-splash = displayio.Group(max_size=10)
+splash = displayio.Group()
 display.show(splash)
 
 color_bitmap = displayio.Bitmap(display.width, display.height, 1)
@@ -56,7 +56,6 @@ text = "Hello World!"
 text_area = label.Label(terminalio.FONT, text=text, color=TEXT_COLOR)
 text_width = text_area.bounding_box[2] * FONTSCALE
 text_group = displayio.Group(
-    max_size=10,
     scale=FONTSCALE,
     x=display.width // 2 - text_width // 2,
     y=display.height // 2,

--- a/examples/st7789_240x240_bonnet_simpletest.py
+++ b/examples/st7789_240x240_bonnet_simpletest.py
@@ -33,7 +33,7 @@ display = ST7789(
 )
 
 # Make the display context
-splash = displayio.Group(max_size=10)
+splash = displayio.Group()
 display.show(splash)
 
 color_bitmap = displayio.Bitmap(240, 240, 1)
@@ -51,7 +51,7 @@ inner_sprite = displayio.TileGrid(inner_bitmap, pixel_shader=inner_palette, x=20
 splash.append(inner_sprite)
 
 # Draw a label
-text_group = displayio.Group(max_size=10, scale=2, x=50, y=120)
+text_group = displayio.Group(scale=2, x=50, y=120)
 text = "Hello World!"
 text_area = label.Label(terminalio.FONT, text=text, color=0xFFFF00)
 text_group.append(text_area)  # Subgroup for text scaling

--- a/examples/st7789_240x240_pitft_simpletest.py
+++ b/examples/st7789_240x240_pitft_simpletest.py
@@ -25,7 +25,7 @@ display_bus = displayio.FourWire(spi, command=tft_dc, chip_select=tft_cs)
 display = ST7789(display_bus, width=240, height=240, rowstart=80, rotation=180)
 
 # Make the display context
-splash = displayio.Group(max_size=10)
+splash = displayio.Group()
 display.show(splash)
 
 color_bitmap = displayio.Bitmap(240, 240, 1)
@@ -43,7 +43,7 @@ inner_sprite = displayio.TileGrid(inner_bitmap, pixel_shader=inner_palette, x=20
 splash.append(inner_sprite)
 
 # Draw a label
-text_group = displayio.Group(max_size=10, scale=2, x=50, y=120)
+text_group = displayio.Group(scale=2, x=50, y=120)
 text = "Hello World!"
 text_area = label.Label(terminalio.FONT, text=text, color=0xFFFF00)
 text_group.append(text_area)  # Subgroup for text scaling

--- a/examples/st7789_240x240_simpletest_Pimoroni_Pico_Explorer.py
+++ b/examples/st7789_240x240_simpletest_Pimoroni_Pico_Explorer.py
@@ -26,7 +26,7 @@ display_bus = displayio.FourWire(spi, command=tft_dc, chip_select=tft_cs)
 display = ST7789(display_bus, width=240, height=240, rowstart=80, rotation=180)
 
 # Make the display context
-splash = displayio.Group(max_size=10)
+splash = displayio.Group()
 display.show(splash)
 
 color_bitmap = displayio.Bitmap(240, 240, 1)
@@ -44,7 +44,7 @@ inner_sprite = displayio.TileGrid(inner_bitmap, pixel_shader=inner_palette, x=20
 splash.append(inner_sprite)
 
 # Draw a label
-text_group = displayio.Group(max_size=10, scale=2, x=50, y=120)
+text_group = displayio.Group(scale=2, x=50, y=120)
 text = "Hello World!"
 text_area = label.Label(terminalio.FONT, text=text, color=0xFFFF00)
 text_group.append(text_area)  # Subgroup for text scaling

--- a/examples/st7789_320x240_simpletest.py
+++ b/examples/st7789_320x240_simpletest.py
@@ -25,7 +25,7 @@ display_bus = displayio.FourWire(
 display = ST7789(display_bus, width=320, height=240, rotation=90)
 
 # Make the display context
-splash = displayio.Group(max_size=10)
+splash = displayio.Group()
 display.show(splash)
 
 color_bitmap = displayio.Bitmap(320, 240, 1)
@@ -43,7 +43,7 @@ inner_sprite = displayio.TileGrid(inner_bitmap, pixel_shader=inner_palette, x=20
 splash.append(inner_sprite)
 
 # Draw a label
-text_group = displayio.Group(max_size=10, scale=3, x=57, y=120)
+text_group = displayio.Group(scale=3, x=57, y=120)
 text = "Hello World!"
 text_area = label.Label(terminalio.FONT, text=text, color=0xFFFF00)
 text_group.append(text_area)  # Subgroup for text scaling

--- a/examples/st7789_simpletest.py
+++ b/examples/st7789_simpletest.py
@@ -25,7 +25,7 @@ display_bus = displayio.FourWire(
 display = ST7789(display_bus, width=240, height=240, rowstart=80)
 
 # Make the display context
-splash = displayio.Group(max_size=10)
+splash = displayio.Group()
 display.show(splash)
 
 color_bitmap = displayio.Bitmap(240, 240, 1)
@@ -43,7 +43,7 @@ inner_sprite = displayio.TileGrid(inner_bitmap, pixel_shader=inner_palette, x=20
 splash.append(inner_sprite)
 
 # Draw a label
-text_group = displayio.Group(max_size=10, scale=2, x=50, y=120)
+text_group = displayio.Group(scale=2, x=50, y=120)
 text = "Hello World!"
 text_area = label.Label(terminalio.FONT, text=text, color=0xFFFF00)
 text_group.append(text_area)  # Subgroup for text scaling

--- a/examples/st7789_tft_gizmo_simpletest.py
+++ b/examples/st7789_tft_gizmo_simpletest.py
@@ -32,7 +32,7 @@ display = ST7789(
 )
 
 # Make the display context
-splash = displayio.Group(max_size=10)
+splash = displayio.Group()
 display.show(splash)
 
 color_bitmap = displayio.Bitmap(240, 240, 1)
@@ -50,7 +50,7 @@ inner_sprite = displayio.TileGrid(inner_bitmap, pixel_shader=inner_palette, x=20
 splash.append(inner_sprite)
 
 # Draw a label
-text_group = displayio.Group(max_size=10, scale=2, x=50, y=120)
+text_group = displayio.Group(scale=2, x=50, y=120)
 text = "Hello World!"
 text_area = label.Label(terminalio.FONT, text=text, color=0xFFFF00)
 text_group.append(text_area)  # Subgroup for text scaling


### PR DESCRIPTION
Remove the `max_size` parameter. It is no longer used by `displayio.Group`
Ref: adafruit/circuitpython#4959

Update the docs to include the examples.

I don't have a ST7789 display to test with.