### PR TITLE
Fix the 280x240 example offsets

### DIFF
--- a/examples/st7789_280x240_simpletest.py
+++ b/examples/st7789_280x240_simpletest.py
@@ -15,8 +15,8 @@ from adafruit_st7789 import ST7789
 displayio.release_displays()
 
 spi = board.SPI()
-tft_cs = board.D10
-tft_dc = board.D8
+tft_cs = board.D5
+tft_dc = board.D6
 
 display_bus = displayio.FourWire(
     spi, command=tft_dc, chip_select=tft_cs, reset=board.D9

--- a/examples/st7789_280x240_simpletest.py
+++ b/examples/st7789_280x240_simpletest.py
@@ -15,20 +15,20 @@ from adafruit_st7789 import ST7789
 displayio.release_displays()
 
 spi = board.SPI()
-tft_cs = board.D5
-tft_dc = board.D6
+tft_cs = board.D10
+tft_dc = board.D8
 
 display_bus = displayio.FourWire(
     spi, command=tft_dc, chip_select=tft_cs, reset=board.D9
 )
 
-display = ST7789(display_bus, width=320, height=240, rotation=90)
+display = ST7789(display_bus, width=280, height=240, rowstart=20, rotation=90)
 
 # Make the display context
 splash = displayio.Group()
 display.show(splash)
 
-color_bitmap = displayio.Bitmap(320, 240, 1)
+color_bitmap = displayio.Bitmap(280, 240, 1)
 color_palette = displayio.Palette(1)
 color_palette[0] = 0x00FF00  # Bright Green
 
@@ -36,14 +36,14 @@ bg_sprite = displayio.TileGrid(color_bitmap, pixel_shader=color_palette, x=0, y=
 splash.append(bg_sprite)
 
 # Draw a smaller inner rectangle
-inner_bitmap = displayio.Bitmap(280, 200, 1)
+inner_bitmap = displayio.Bitmap(240, 200, 1)
 inner_palette = displayio.Palette(1)
 inner_palette[0] = 0xAA0088  # Purple
 inner_sprite = displayio.TileGrid(inner_bitmap, pixel_shader=inner_palette, x=20, y=20)
 splash.append(inner_sprite)
 
 # Draw a label
-text_group = displayio.Group(scale=3, x=57, y=120)
+text_group = displayio.Group(scale=3, x=37, y=120)
 text = "Hello World!"
 text_area = label.Label(terminalio.FONT, text=text, color=0xFFFF00)
 text_group.append(text_area)  # Subgroup for text scaling


### PR DESCRIPTION
Apparently my last PR was just a copy of the 320x240 example without the offset changes saved. This fixes it.