### PR TITLE
Add example for Waveshare Pico LCD 1.3

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -79,3 +79,10 @@ Pimoroni Pico Display Pack 2.0
 .. literalinclude:: ../examples/st7789_320x240_simpletest_Pimoroni_Pico_Display_2_0.py
     :caption: examples/st7789_320x240_simpletest_Pimoroni_Pico_Display_2_0.py
     :linenos:
+
+Waveshare Pico LCD 1.3
+==============================
+
+.. literalinclude:: ../examples/st7789_240x240_simpletest_Waveshare_PicoLCD_1_3.py
+    :caption: examples/st7789_240x240_simpletest_Waveshare_PicoLCD_1_3.py
+    :linenos:

--- a/examples/st7789_240x240_simpletest_Waveshare_PicoLCD_1_3.py
+++ b/examples/st7789_240x240_simpletest_Waveshare_PicoLCD_1_3.py
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: 2021 ladyada for Adafruit Industries
+# SPDX-License-Identifier: MIT
+
+"""
+This test will initialize the display using displayio and draw a solid green
+background, a smaller purple rectangle, and some yellow text.
+"""
+import board
+import busio
+import terminalio
+import displayio
+from adafruit_display_text import label
+from adafruit_st7789 import ST7789
+
+# Release any resources currently in use for the displays
+displayio.release_displays()
+
+tft_dc = board.GP8
+tft_cs = board.GP9
+spi_clk = board.GP10
+spi_mosi = board.GP11
+tft_rst = board.GP12
+backlight = board.GP13
+spi = busio.SPI(spi_clk, spi_mosi)
+
+display_bus = displayio.FourWire(spi, command=tft_dc, chip_select=tft_cs, reset=tft_rst)
+
+display = ST7789(
+    display_bus, rotation=270, width=240, height=240, rowstart=80, backlight_pin=backlight
+)
+
+# Make the display context
+splash = displayio.Group()
+display.show(splash)
+
+color_bitmap = displayio.Bitmap(240, 240, 1)
+color_palette = displayio.Palette(1)
+color_palette[0] = 0x00FF00  # Bright Green
+
+bg_sprite = displayio.TileGrid(color_bitmap, pixel_shader=color_palette, x=0, y=0)
+splash.append(bg_sprite)
+
+# Draw a smaller inner rectangle
+inner_bitmap = displayio.Bitmap(200, 200, 1)
+inner_palette = displayio.Palette(1)
+inner_palette[0] = 0xAA0088  # Purple
+inner_sprite = displayio.TileGrid(inner_bitmap, pixel_shader=inner_palette, x=20, y=20)
+splash.append(inner_sprite)
+
+# Draw a label
+text_group = displayio.Group(scale=2, x=50, y=120)
+text = "Hello World!"
+text_area = label.Label(terminalio.FONT, text=text, color=0xFFFF00)
+text_group.append(text_area)  # Subgroup for text scaling
+splash.append(text_group)
+
+while True:
+    pass

--- a/examples/st7789_240x240_simpletest_Waveshare_PicoLCD_1_3.py
+++ b/examples/st7789_240x240_simpletest_Waveshare_PicoLCD_1_3.py
@@ -26,7 +26,12 @@ spi = busio.SPI(spi_clk, spi_mosi)
 display_bus = displayio.FourWire(spi, command=tft_dc, chip_select=tft_cs, reset=tft_rst)
 
 display = ST7789(
-    display_bus, rotation=270, width=240, height=240, rowstart=80, backlight_pin=backlight
+    display_bus,
+    rotation=270,
+    width=240,
+    height=240,
+    rowstart=80,
+    backlight_pin=backlight,
 )
 
 # Make the display context


### PR DESCRIPTION
Adds example for https://www.waveshare.com/wiki/Pico-LCD-1.3
