### PR TITLE
Added examples for 1.47" and 1.9" displays

### DIFF
--- a/examples/st7789_170x320_1.9_simpletest.py
+++ b/examples/st7789_170x320_1.9_simpletest.py
@@ -22,9 +22,7 @@ tft_cs = board.D5
 tft_dc = board.D6
 tft_rst = board.D9
 
-display_bus = displayio.FourWire(
-    spi, command=tft_dc, chip_select=tft_cs, reset=tft_rst
-)
+display_bus = displayio.FourWire(spi, command=tft_dc, chip_select=tft_cs, reset=tft_rst)
 
 display = ST7789(display_bus, width=320, height=170, colstart=34, rotation=90)
 
@@ -39,20 +37,24 @@ bg_sprite = displayio.TileGrid(color_bitmap, pixel_shader=color_palette, x=0, y=
 splash.append(bg_sprite)
 
 # Draw a smaller inner rectangle
-inner_bitmap = displayio.Bitmap(display.width - (BORDER_WIDTH * 2), display.height - (BORDER_WIDTH * 2), 1)
+inner_bitmap = displayio.Bitmap(
+    display.width - (BORDER_WIDTH * 2), display.height - (BORDER_WIDTH * 2), 1
+)
 inner_palette = displayio.Palette(1)
 inner_palette[0] = 0xAA0088  # Purple
-inner_sprite = displayio.TileGrid(inner_bitmap, pixel_shader=inner_palette, x=BORDER_WIDTH, y=BORDER_WIDTH)
+inner_sprite = displayio.TileGrid(
+    inner_bitmap, pixel_shader=inner_palette, x=BORDER_WIDTH, y=BORDER_WIDTH
+)
 splash.append(inner_sprite)
 
 # Draw a label
 text_area = label.Label(
-    terminalio.FONT, 
+    terminalio.FONT,
     text="Hello World!",
     color=0xFFFF00,
     scale=TEXT_SCALE,
     anchor_point=(0.5, 0.5),
-    anchored_position=(display.width // 2, display.height // 2)
+    anchored_position=(display.width // 2, display.height // 2),
 )
 splash.append(text_area)
 

--- a/examples/st7789_170x320_1.9_simpletest.py
+++ b/examples/st7789_170x320_1.9_simpletest.py
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: 2021 ladyada for Adafruit Industries
+# SPDX-License-Identifier: MIT
+
+"""
+This test will initialize the display using displayio and draw a solid green
+background, a smaller purple rectangle, and some yellow text.
+"""
+import board
+import terminalio
+import displayio
+from adafruit_display_text import label
+from adafruit_st7789 import ST7789
+
+BORDER_WIDTH = 20
+TEXT_SCALE = 3
+
+# Release any resources currently in use for the displays
+displayio.release_displays()
+
+spi = board.SPI()
+tft_cs = board.D5
+tft_dc = board.D6
+tft_rst = board.D9
+
+display_bus = displayio.FourWire(
+    spi, command=tft_dc, chip_select=tft_cs, reset=tft_rst
+)
+
+display = ST7789(display_bus, width=320, height=170, colstart=34, rotation=90)
+
+# Make the display context
+splash = displayio.Group()
+display.show(splash)
+
+color_bitmap = displayio.Bitmap(display.width, display.height, 1)
+color_palette = displayio.Palette(1)
+color_palette[0] = 0x00FF00  # Bright Green
+bg_sprite = displayio.TileGrid(color_bitmap, pixel_shader=color_palette, x=0, y=0)
+splash.append(bg_sprite)
+
+# Draw a smaller inner rectangle
+inner_bitmap = displayio.Bitmap(display.width - (BORDER_WIDTH * 2), display.height - (BORDER_WIDTH * 2), 1)
+inner_palette = displayio.Palette(1)
+inner_palette[0] = 0xAA0088  # Purple
+inner_sprite = displayio.TileGrid(inner_bitmap, pixel_shader=inner_palette, x=BORDER_WIDTH, y=BORDER_WIDTH)
+splash.append(inner_sprite)
+
+# Draw a label
+text_area = label.Label(
+    terminalio.FONT, 
+    text="Hello World!",
+    color=0xFFFF00,
+    scale=TEXT_SCALE,
+    anchor_point=(0.5, 0.5),
+    anchored_position=(display.width // 2, display.height // 2)
+)
+splash.append(text_area)
+
+while True:
+    pass

--- a/examples/st7789_172x320_1.47_simpletest.py
+++ b/examples/st7789_172x320_1.47_simpletest.py
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: 2021 ladyada for Adafruit Industries
+# SPDX-License-Identifier: MIT
+
+"""
+This test will initialize the display using displayio and draw a solid green
+background, a smaller purple rectangle, and some yellow text.
+"""
+import board
+import terminalio
+import displayio
+from adafruit_display_text import label
+from adafruit_st7789 import ST7789
+
+BORDER_WIDTH = 20
+TEXT_SCALE = 3
+
+# Release any resources currently in use for the displays
+displayio.release_displays()
+
+spi = board.SPI()
+tft_cs = board.D5
+tft_dc = board.D6
+tft_rst = board.D9
+
+display_bus = displayio.FourWire(
+    spi, command=tft_dc, chip_select=tft_cs, reset=tft_rst
+)
+
+display = ST7789(display_bus, width=320, height=172, colstart=34, rotation=270)
+
+# Make the display context
+splash = displayio.Group()
+display.show(splash)
+
+color_bitmap = displayio.Bitmap(display.width, display.height, 1)
+color_palette = displayio.Palette(1)
+color_palette[0] = 0x00FF00  # Bright Green
+bg_sprite = displayio.TileGrid(color_bitmap, pixel_shader=color_palette, x=0, y=0)
+splash.append(bg_sprite)
+
+# Draw a smaller inner rectangle
+inner_bitmap = displayio.Bitmap(display.width - (BORDER_WIDTH * 2), display.height - (BORDER_WIDTH * 2), 1)
+inner_palette = displayio.Palette(1)
+inner_palette[0] = 0xAA0088  # Purple
+inner_sprite = displayio.TileGrid(inner_bitmap, pixel_shader=inner_palette, x=BORDER_WIDTH, y=BORDER_WIDTH)
+splash.append(inner_sprite)
+
+# Draw a label
+text_area = label.Label(
+    terminalio.FONT, 
+    text="Hello World!",
+    color=0xFFFF00,
+    scale=TEXT_SCALE,
+    anchor_point=(0.5, 0.5),
+    anchored_position=(display.width // 2, display.height // 2)
+)
+splash.append(text_area)
+
+while True:
+    pass

--- a/examples/st7789_172x320_1.47_simpletest.py
+++ b/examples/st7789_172x320_1.47_simpletest.py
@@ -22,9 +22,7 @@ tft_cs = board.D5
 tft_dc = board.D6
 tft_rst = board.D9
 
-display_bus = displayio.FourWire(
-    spi, command=tft_dc, chip_select=tft_cs, reset=tft_rst
-)
+display_bus = displayio.FourWire(spi, command=tft_dc, chip_select=tft_cs, reset=tft_rst)
 
 display = ST7789(display_bus, width=320, height=172, colstart=34, rotation=270)
 
@@ -39,20 +37,24 @@ bg_sprite = displayio.TileGrid(color_bitmap, pixel_shader=color_palette, x=0, y=
 splash.append(bg_sprite)
 
 # Draw a smaller inner rectangle
-inner_bitmap = displayio.Bitmap(display.width - (BORDER_WIDTH * 2), display.height - (BORDER_WIDTH * 2), 1)
+inner_bitmap = displayio.Bitmap(
+    display.width - (BORDER_WIDTH * 2), display.height - (BORDER_WIDTH * 2), 1
+)
 inner_palette = displayio.Palette(1)
 inner_palette[0] = 0xAA0088  # Purple
-inner_sprite = displayio.TileGrid(inner_bitmap, pixel_shader=inner_palette, x=BORDER_WIDTH, y=BORDER_WIDTH)
+inner_sprite = displayio.TileGrid(
+    inner_bitmap, pixel_shader=inner_palette, x=BORDER_WIDTH, y=BORDER_WIDTH
+)
 splash.append(inner_sprite)
 
 # Draw a label
 text_area = label.Label(
-    terminalio.FONT, 
+    terminalio.FONT,
     text="Hello World!",
     color=0xFFFF00,
     scale=TEXT_SCALE,
     anchor_point=(0.5, 0.5),
-    anchored_position=(display.width // 2, display.height // 2)
+    anchored_position=(display.width // 2, display.height // 2),
 )
 splash.append(text_area)
 


### PR DESCRIPTION
I also updated the examples to be more readable and updated positioning to be automatic instead of using so many hard-coded values.