### PR TITLE
Minor changes to the ST7789 1.47 Example that were required to work with raspberry pi pico w

### DIFF
--- a/examples/st7789_172x320_1.47_simpletest.py
+++ b/examples/st7789_172x320_1.47_simpletest.py
@@ -18,11 +18,21 @@ TEXT_SCALE = 3
 # Release any resources currently in use for the displays
 displayio.release_displays()
 
-tft_cs = board.GP5  # board.D5
-tft_dc = board.GP6  # board.D6
-tft_rst = board.GP7  # board.D7
+# built-in, silkscreen labelled SPI bus  
+spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
+tft_cs = board.D5
+tft_dc = board.D6
+tft_rst = board.D9
 
-spi = busio.SPI(board.GP2, board.GP3, board.GP4)
+# If using a Raspberry Pi Pico or Pico-w 
+# Uncomment the below code to use GP (General Purpose) pins 
+# instead of D (Digital)
+
+# spi = busio.SPI(board.GP2, board.GP3, board.GP4)
+# tft_cs = board.GP5
+# tft_dc = board.GP6
+# tft_rst = board.GP7
+
 display_bus = displayio.FourWire(spi, command=tft_dc, chip_select=tft_cs, reset=tft_rst)
 
 display = ST7789(display_bus, width=320, height=172, colstart=34, rotation=270)

--- a/examples/st7789_172x320_1.47_simpletest.py
+++ b/examples/st7789_172x320_1.47_simpletest.py
@@ -3,25 +3,26 @@
 
 """
 This test will initialize the display using displayio and draw a solid green
-background, a smaller purple rectangle, and some yellow text.
+background, a smaller purple rectangle, and some yellow text..
 """
 import board
+import busio
 import terminalio
 import displayio
 from adafruit_display_text import label
 from adafruit_st7789 import ST7789
 
-BORDER_WIDTH = 20
+BORDER_WIDTH = 28
 TEXT_SCALE = 3
 
 # Release any resources currently in use for the displays
 displayio.release_displays()
 
-spi = board.SPI()
-tft_cs = board.D5
-tft_dc = board.D6
-tft_rst = board.D9
+tft_cs = board.GP5 #board.D5
+tft_dc = board.GP6 #board.D6
+tft_rst = board.GP7 #board.D7
 
+spi = busio.SPI(board.GP2, board.GP3, board.GP4)
 display_bus = displayio.FourWire(spi, command=tft_dc, chip_select=tft_cs, reset=tft_rst)
 
 display = ST7789(display_bus, width=320, height=172, colstart=34, rotation=270)
@@ -34,12 +35,13 @@ color_bitmap = displayio.Bitmap(display.width, display.height, 1)
 color_palette = displayio.Palette(1)
 color_palette[0] = 0x00FF00  # Bright Green
 bg_sprite = displayio.TileGrid(color_bitmap, pixel_shader=color_palette, x=0, y=0)
-splash.append(bg_sprite)
+splash.append(bg_sprite) 
 
 # Draw a smaller inner rectangle
 inner_bitmap = displayio.Bitmap(
     display.width - (BORDER_WIDTH * 2), display.height - (BORDER_WIDTH * 2), 1
 )
+
 inner_palette = displayio.Palette(1)
 inner_palette[0] = 0xAA0088  # Purple
 inner_sprite = displayio.TileGrid(
@@ -50,7 +52,7 @@ splash.append(inner_sprite)
 # Draw a label
 text_area = label.Label(
     terminalio.FONT,
-    text="Hello World!",
+    text="Hello World!!",
     color=0xFFFF00,
     scale=TEXT_SCALE,
     anchor_point=(0.5, 0.5),

--- a/examples/st7789_172x320_1.47_simpletest.py
+++ b/examples/st7789_172x320_1.47_simpletest.py
@@ -18,9 +18,9 @@ TEXT_SCALE = 3
 # Release any resources currently in use for the displays
 displayio.release_displays()
 
-tft_cs = board.GP5 #board.D5
-tft_dc = board.GP6 #board.D6
-tft_rst = board.GP7 #board.D7
+tft_cs = board.GP5  # board.D5
+tft_dc = board.GP6  # board.D6
+tft_rst = board.GP7  # board.D7
 
 spi = busio.SPI(board.GP2, board.GP3, board.GP4)
 display_bus = displayio.FourWire(spi, command=tft_dc, chip_select=tft_cs, reset=tft_rst)
@@ -35,7 +35,7 @@ color_bitmap = displayio.Bitmap(display.width, display.height, 1)
 color_palette = displayio.Palette(1)
 color_palette[0] = 0x00FF00  # Bright Green
 bg_sprite = displayio.TileGrid(color_bitmap, pixel_shader=color_palette, x=0, y=0)
-splash.append(bg_sprite) 
+splash.append(bg_sprite)
 
 # Draw a smaller inner rectangle
 inner_bitmap = displayio.Bitmap(

--- a/examples/st7789_172x320_1.47_simpletest.py
+++ b/examples/st7789_172x320_1.47_simpletest.py
@@ -3,7 +3,7 @@
 
 """
 This test will initialize the display using displayio and draw a solid green
-background, a smaller purple rectangle, and some yellow text..
+background, a smaller purple rectangle, and some yellow text.
 """
 import board
 import busio
@@ -12,6 +12,7 @@ import displayio
 from adafruit_display_text import label
 from adafruit_st7789 import ST7789
 
+
 BORDER_WIDTH = 28
 TEXT_SCALE = 3
 
@@ -19,7 +20,7 @@ TEXT_SCALE = 3
 displayio.release_displays()
 
 # built-in, silkscreen labelled SPI bus  
-spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
+spi = board.SPI()
 tft_cs = board.D5
 tft_dc = board.D6
 tft_rst = board.D9
@@ -62,7 +63,7 @@ splash.append(inner_sprite)
 # Draw a label
 text_area = label.Label(
     terminalio.FONT,
-    text="Hello World!!",
+    text="Hello World!",
     color=0xFFFF00,
     scale=TEXT_SCALE,
     anchor_point=(0.5, 0.5),

--- a/examples/st7789_172x320_1.47_simpletest.py
+++ b/examples/st7789_172x320_1.47_simpletest.py
@@ -6,7 +6,6 @@ This test will initialize the display using displayio and draw a solid green
 background, a smaller purple rectangle, and some yellow text.
 """
 import board
-import busio
 import terminalio
 import displayio
 from adafruit_display_text import label
@@ -19,16 +18,17 @@ TEXT_SCALE = 3
 # Release any resources currently in use for the displays
 displayio.release_displays()
 
-# built-in, silkscreen labelled SPI bus  
+# built-in, silkscreen labelled SPI bus
 spi = board.SPI()
 tft_cs = board.D5
 tft_dc = board.D6
 tft_rst = board.D9
 
-# If using a Raspberry Pi Pico or Pico-w 
-# Uncomment the below code to use GP (General Purpose) pins 
+# If using a Raspberry Pi Pico or Pico-w
+# Uncomment the below code to use GP (General Purpose) pins
 # instead of D (Digital)
 
+# import busio
 # spi = busio.SPI(board.GP2, board.GP3, board.GP4)
 # tft_cs = board.GP5
 # tft_dc = board.GP6


### PR DESCRIPTION
Small changes to work with Circuit Python 8 Beta 4 on Raspberry Pi Pico. board.SPI didn't exist and needed to be changed to busio.SPI. 

The Dx reference for pins doesn't work and needs updated to be GPx (for the raspberry pi pico at least)

I am unaware if this is across the board, or just for the pico w or just CP8. But I thought I would share as it's taken me quite a while to figure this out.

Also... again this might be an eccentricity of the waveshare 1.47 board, but I had to power it from external 3v3 BEFORE booting my board for this code to work. When trying to drive it from any of the Picos outputs, the screen was either incredibly dim or simply didn't work, it would be great to mention that in documentation on the site somewhere if that's common. 