### PR TITLE
Update st7789_280x240_simpletest.py

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,18 +4,18 @@
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v4.5.0
     hooks:
       - id: check-yaml
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.11
+    rev: v0.3.4
     hooks:
-      - id: ruff-check
-        args: ["--fix"]
       - id: ruff-format
+      - id: ruff
+        args: ["--fix"]
   - repo: https://github.com/fsfe/reuse-tool
-    rev: v5.0.2
+    rev: v3.0.1
     hooks:
       - id: reuse

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,18 +4,18 @@
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v5.0.0
     hooks:
       - id: check-yaml
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.3.4
+    rev: v0.11.11
     hooks:
       - id: ruff-format
-      - id: ruff
+      - id: ruff-check
         args: ["--fix"]
   - repo: https://github.com/fsfe/reuse-tool
-    rev: v3.0.1
+    rev: v5.0.2
     hooks:
       - id: reuse

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,9 +12,9 @@ repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.11.11
     hooks:
-      - id: ruff-format
       - id: ruff-check
         args: ["--fix"]
+      - id: ruff-format
   - repo: https://github.com/fsfe/reuse-tool
     rev: v5.0.2
     hooks:

--- a/examples/st7789_280x240_simpletest.py
+++ b/examples/st7789_280x240_simpletest.py
@@ -12,6 +12,7 @@ import displayio
 import terminalio
 from adafruit_display_text import label
 from fourwire import FourWire
+
 from adafruit_st7789 import ST7789
 
 # set the display rotation

--- a/examples/st7789_280x240_simpletest.py
+++ b/examples/st7789_280x240_simpletest.py
@@ -2,8 +2,9 @@
 # SPDX-License-Identifier: MIT
 
 """
-This test will initialize the display using displayio and draw a solid green
-background, a smaller purple rectangle, and some yellow text.
+This test will initialize the display using displayio, set display brightness and draw a solid green
+background, a smaller purple rectangle, and some yellow text. The test also has the option of
+rotating the screen content.
 """
 
 import board
@@ -11,40 +12,59 @@ import displayio
 import terminalio
 from adafruit_display_text import label
 from fourwire import FourWire
-
 from adafruit_st7789 import ST7789
+
+# set the display rotation
+rotation = 90
+if rotation not in (0, 90, 180, 270):
+    raise ValueError("The value of rotation must be one of: 0, 90, 180, 270")
+
+# Display settings depending on the selected rotation
+# first value default setting for 1.69" with 0° and 180° rotation
+# second value default setting for 1.69" with 90° and 270° rotation
+width = 240 if rotation in (0, 180) else 280
+height = 280 if rotation in (0, 180) else 240
+color_bitmap_x = 240 if rotation in (0, 180) else 280
+color_bitmap_y = 280 if rotation in (0, 180) else 240
+inner_bitmap_x = 200 if rotation in (0, 180) else 240
+inner_bitmap_y = 240 if rotation in (0, 180) else 200
+scale = 2 if rotation in (0, 180) else 3
+x = 50 if rotation in (0, 180) else 37
+y = 140 if rotation in (0, 180) else 120
 
 # Release any resources currently in use for the displays
 displayio.release_displays()
-
 spi = board.SPI()
-tft_cs = board.D5
-tft_dc = board.D6
+tft_cs = board.D20
+tft_dc = board.D21
+backlight = board.D6
+display_bus = FourWire(spi, command=tft_dc, chip_select=tft_cs, reset=board.D5)
+display = ST7789(display_bus, width=width, height=height, colstart=0, rowstart=20, rotation=rotation, backlight_pin=backlight, bgr=True, invert=True)
 
-display_bus = FourWire(spi, command=tft_dc, chip_select=tft_cs, reset=board.D9)
-
-display = ST7789(display_bus, width=280, height=240, rowstart=20, rotation=90)
+# set the backlight
+# minimum value 0.001 (0.000 would be off), maximum value 1.000
+display.brightness = 0.5
 
 # Make the display context
 splash = displayio.Group()
 display.root_group = splash
 
-color_bitmap = displayio.Bitmap(280, 240, 1)
+# Draw background rectangle
+color_bitmap = displayio.Bitmap(color_bitmap_x, color_bitmap_y, 1)
 color_palette = displayio.Palette(1)
 color_palette[0] = 0x00FF00  # Bright Green
-
 bg_sprite = displayio.TileGrid(color_bitmap, pixel_shader=color_palette, x=0, y=0)
 splash.append(bg_sprite)
 
 # Draw a smaller inner rectangle
-inner_bitmap = displayio.Bitmap(240, 200, 1)
+inner_bitmap = displayio.Bitmap(inner_bitmap_x, inner_bitmap_y, 1)
 inner_palette = displayio.Palette(1)
 inner_palette[0] = 0xAA0088  # Purple
 inner_sprite = displayio.TileGrid(inner_bitmap, pixel_shader=inner_palette, x=20, y=20)
 splash.append(inner_sprite)
 
 # Draw a label
-text_group = displayio.Group(scale=3, x=37, y=120)
+text_group = displayio.Group(scale=scale, x=x, y=y)
 text = "Hello World!"
 text_area = label.Label(terminalio.FONT, text=text, color=0xFFFF00)
 text_group.append(text_area)  # Subgroup for text scaling

--- a/examples/st7789_280x240_simpletest.py
+++ b/examples/st7789_280x240_simpletest.py
@@ -17,7 +17,7 @@ from adafruit_st7789 import ST7789
 
 # set the display rotation
 rotation = 90
-if rotation not in (0, 90, 180, 270):
+if rotation not in {0, 90, 180, 270}:
     raise ValueError("The value of rotation must be one of: 0, 90, 180, 270")
 
 # Display settings depending on the selected rotation

--- a/examples/st7789_280x240_simpletest.py
+++ b/examples/st7789_280x240_simpletest.py
@@ -23,15 +23,15 @@ if rotation not in (0, 90, 180, 270):
 # Display settings depending on the selected rotation
 # first value default setting for 1.69" with 0° and 180° rotation
 # second value default setting for 1.69" with 90° and 270° rotation
-width = 240 if rotation in (0, 180) else 280
-height = 280 if rotation in (0, 180) else 240
-color_bitmap_x = 240 if rotation in (0, 180) else 280
-color_bitmap_y = 280 if rotation in (0, 180) else 240
-inner_bitmap_x = 200 if rotation in (0, 180) else 240
-inner_bitmap_y = 240 if rotation in (0, 180) else 200
-scale = 2 if rotation in (0, 180) else 3
-x = 50 if rotation in (0, 180) else 37
-y = 140 if rotation in (0, 180) else 120
+width = 240 if rotation in {0, 180} else 280
+height = 280 if rotation in {0, 180} else 240
+color_bitmap_x = 240 if rotation in {0, 180} else 280
+color_bitmap_y = 280 if rotation in {0, 180} else 240
+inner_bitmap_x = 200 if rotation in {0, 180} else 240
+inner_bitmap_y = 240 if rotation in {0, 180} else 200
+scale = 2 if rotation in {0, 180} else 3
+x = 50 if rotation in {0, 180} else 37
+y = 140 if rotation in {0, 180} else 120
 
 # Release any resources currently in use for the displays
 displayio.release_displays()

--- a/examples/st7789_280x240_simpletest.py
+++ b/examples/st7789_280x240_simpletest.py
@@ -39,7 +39,17 @@ tft_cs = board.D20
 tft_dc = board.D21
 backlight = board.D6
 display_bus = FourWire(spi, command=tft_dc, chip_select=tft_cs, reset=board.D5)
-display = ST7789(display_bus, width=width, height=height, colstart=0, rowstart=20, rotation=rotation, backlight_pin=backlight, bgr=True, invert=True)
+display = ST7789(
+    display_bus,
+    width=width,
+    height=height,
+    colstart=0,
+    rowstart=20,
+    rotation=rotation,
+    backlight_pin=backlight,
+    bgr=True,
+    invert=True,
+)
 
 # set the backlight
 # minimum value 0.001 (0.000 would be off), maximum value 1.000


### PR DESCRIPTION
Hello makermelissa,

This is PR for an extended test code of st7789_280x240_simpletest.py.

Now the backlight setting and an automatic offset correction of the ST7789 display driver at a resolution of 280x240 (1.69", Product ID: 5206) is included.

#Issue 
Add an extended version of st7789_280x240_simpletest.py #42 
#Pull Request  
Enhanced compatibility #40

Thank you for your work and that of the community!

With kind regards
CrackXT